### PR TITLE
Change parameter name from radius to diameter

### DIFF
--- a/chp13_mathematics/example_13_08_recursion/example_13_08_recursion.pde
+++ b/chp13_mathematics/example_13_08_recursion/example_13_08_recursion.pde
@@ -15,13 +15,13 @@ void draw() {
   drawCircle(width/2, height/2, 300);
 }
 
-void drawCircle(float x, float y, float radius) {
-  ellipse(x, y, radius, radius);
-  if (radius > 2) {
+void drawCircle(float x, float y, float diameter) {
+  ellipse(x, y, diameter, diameter);
+  if (diameter > 2) {
     // drawCircle() calls itself twice, creating a branching effect. 
     // For every circle, a smaller circle is drawn to the left and right.
-    drawCircle(x + radius/2, y, radius/2);
-    drawCircle(x - radius/2, y, radius/2);
+    drawCircle(x + diameter/2, y, diameter/2);
+    drawCircle(x - diameter/2, y, diameter/2);
   }
 }
 


### PR DESCRIPTION
 since ellipse function takes width and height as parameters, and height and width of a circle = diameter, not radius. Or we could set ellipseMode to RADIUS in the setup?