### PR TITLE
Improve use of comments in exercise 6-4

### DIFF
--- a/chp06_loops/exercise_06_04_global_vs_local/exercise_06_04_global_vs_local.pde
+++ b/chp06_loops/exercise_06_04_global_vs_local/exercise_06_04_global_vs_local.pde
@@ -17,10 +17,10 @@ void draw() {
   count = count + 1;
   background(count);
 }
-________
-
-
+// ________
 */
+
+/*
 //SKETCH #2: Local "count"
 
 void setup() {
@@ -32,6 +32,5 @@ void draw() {
   count = count + 1;
   background(count);
 }
-/*
-________
+// ________
 */


### PR DESCRIPTION
Both sketches start out wrapped by a multi line comment, so they are disabled
by default.  Removing the multi line comment around a sketch will enable it.

The line where the student is supposed to type the answer (indicated by
underscores ________) is now a single line comment. The underscores will thus no
longer prevent either of the sketches from running by producing an unexpected
token error.